### PR TITLE
fix: Publish package without prefixing tag with `v`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ source = "uv-dynamic-versioning"
 
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.1"
+pattern = "default-unprefixed"
 vcs = "git"
 style = "pep440"
 


### PR DESCRIPTION
https://pypi.org/project/deepnote-sqlalchemy-redshift/#history 🎉 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version pattern configuration in project build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->